### PR TITLE
feat: password reset flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,12 @@
     "prestart": "yarn docs",
     "start": "cross-env NODE_ENV=production pm2 start ./src/index.js",
     "dev": "nodemon ./src/index.js",
-    "lint":
-      "eslint **/*.js --ignore-path .gitignore --ignore-pattern internals/scripts",
+    "lint": "eslint **/*.js --ignore-path .gitignore --ignore-pattern internals/scripts",
     "lint:fix": "yarn lint -- --fix",
     "lint:watch": "yarn lint -- --watch",
-    "test":
-      "cross-env NODE_ENV=test nyc --reporter=html --reporter=text mocha --timeout 20000 --recursive src/api/tests",
+    "test": "cross-env NODE_ENV=test nyc --reporter=html --reporter=text mocha --timeout 20000 --recursive src/api/tests",
     "test:unit": "cross-env NODE_ENV=test mocha src/api/tests/unit",
-    "test:integration":
-      "cross-env NODE_ENV=test mocha --timeout 20000 src/api/tests/integration",
+    "test:integration": "cross-env NODE_ENV=test mocha --timeout 20000 src/api/tests/integration",
     "test:watch": "cross-env NODE_ENV=test mocha --watch src/api/tests/unit",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "postcoverage": "opn coverage/lcov-report/index.html",
@@ -33,14 +30,10 @@
     "postpublish": "git push --tags",
     "docs": "apidoc -i src -o docs",
     "postdocs": "opn docs/index.html",
-    "docker:start":
-      "cross-env NODE_ENV=production pm2-docker start ./src/index.js",
-    "docker:prod":
-      "docker-compose -f docker-compose.yml -f docker-compose.prod.yml up",
-    "docker:dev":
-      "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up",
-    "docker:test":
-      "docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit"
+    "docker:start": "cross-env NODE_ENV=production pm2-docker start ./src/index.js",
+    "docker:prod": "docker-compose -f docker-compose.yml -f docker-compose.prod.yml up",
+    "docker:dev": "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up",
+    "docker:test": "docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit"
   },
   "repository": {
     "type": "git",
@@ -89,6 +82,7 @@
     "moment-timezone": "^0.5.13",
     "mongoose": "^4.9.7",
     "morgan": "^1.8.1",
+    "nodemailer": "^4.1.2",
     "passport": "^0.4.0",
     "passport-http-bearer": "^1.0.1",
     "passport-jwt": "3.0.0",

--- a/src/api/middlewares/error.js
+++ b/src/api/middlewares/error.js
@@ -34,7 +34,7 @@ exports.converter = (err, req, res, next) => {
 
   if (err instanceof expressValidation.ValidationError) {
     convertedError = new APIError({
-      message: 'Erro de Validação',
+      message: 'Validation error',
       errors: err.errors,
       status: err.status,
       stack: err.stack,

--- a/src/api/routes/v1/auth.route.js
+++ b/src/api/routes/v1/auth.route.js
@@ -6,6 +6,7 @@ const {
   login,
   register,
   passwordReset,
+  passwordResetChange,
   // oAuth,
   refresh,
 } = require('../../validations/auth.validation');
@@ -70,10 +71,34 @@ router.route('/register').post(validate(register), controller.register);
  */
 router.route('/login').post(validate(login), controller.login);
 
+/**
+ * @api {post} v1/auth/password/reset Password Reset Request
+ * @apiDescription Request a password reset for a given user/email
+ * @apiVersion 1.0.0
+ * @apiName Password
+ * @apiGroup Auth
+ * @apiPermission public
+ *
+ * @apiParam  {String}         email     User's email
+ * @apiParam  {String}         url       Link to your reset password page/form
+ *
+ * @apiSuccess  {String}  user.id             User's id
+ * @apiSuccess  {String}  user.name           User's name
+ * @apiSuccess  {String}  user.email          User's email
+ * @apiSuccess  {String}  user.role           User's role
+ * @apiSuccess  {Date}    user.createdAt      Timestamp
+ * 
+ * @apiSuccess  {String}  message             Message noting an email was sent
+ *
+ * @apiError (Bad Request 400)   ValidationError  Missing email and/or url parameters
+ * @apiError (Not Found 404)     ValidationError  Email in request was not found 
+ * @apiError (Conflict 409)      BadState         An existing, non-expired reset token already exists
+ */
+router.route('/password/reset').post(validate(passwordReset), controller.passwordReset);
+
 router
   .route('/password/reset/change')
   .post(validate(passwordResetChange), controller.passwordResetChange);
-router.route('/password/reset').post(validate(passwordReset), controller.passwordReset);
 
 /**
  * @api {post} v1/auth/refresh-token Refresh Token

--- a/src/api/tests/integration/auth.test.js
+++ b/src/api/tests/integration/auth.test.js
@@ -6,22 +6,16 @@ const sinon = require('sinon');
 const app = require('../../../index');
 const User = require('../../models/user.model');
 const RefreshToken = require('../../models/refreshToken.model');
+const ResetToken = require('../../models/resetToken.model');
 const authProviders = require('../../services/authProviders');
 
 const sandbox = sinon.createSandbox();
-
-const fakeOAuthRequest = () => Promise.resolve({
-  service: 'facebook',
-  id: '123',
-  name: 'user',
-  email: 'test@test.com',
-  picture: 'test.jpg',
-});
 
 describe('Authentication API', () => {
   let dbUser;
   let user;
   let refreshToken;
+  let resetToken;
 
   beforeEach(async () => {
     dbUser = {
@@ -38,15 +32,26 @@ describe('Authentication API', () => {
     };
 
     refreshToken = {
-      token: '5947397b323ae82d8c3a333b.c69d0435e62c9f4953af912442a3d064e20291f0d228c0552ed4be473e7d191ba40b18c2c47e8b9d',
+      token:
+        '5947397b323ae82d8c3a333b.c69d0435e62c9f4953af912442a3d064e20291f0d228c0552ed4be473e7d191ba40b18c2c47e8b9d',
       userId: '5947397b323ae82d8c3a333b',
       userEmail: dbUser.email,
       expires: new Date(),
     };
 
+    resetToken = {
+      token:
+        '5947397b323ae82d8c3a333b.c69d0435e62c9f4953af912442a3d064e20291f0d228c0552ed4be473e7d191ba40b18c2c47e8b9d',
+      userId: '5947397b323ae82d8c3a333b',
+      userEmail: dbUser.email,
+      expires: new Date(),
+      resetUrl: 'http://tandem.ly',
+    };
+
     await User.remove({});
     await User.create(dbUser);
     await RefreshToken.remove({});
+    await ResetToken.remove({});
   });
 
   afterEach(() => sandbox.restore());
@@ -159,7 +164,7 @@ describe('Authentication API', () => {
         });
     });
 
-    it('should report error when email and password don\'t match', () => {
+    it("should report error when email and password don't match", () => {
       return request(app)
         .post('/v1/auth/login')
         .send(user)
@@ -173,97 +178,97 @@ describe('Authentication API', () => {
     });
   });
 
-  describe('POST /v1/auth/facebook', () => {
-    it('should create a new user and return an accessToken when user does not exist', () => {
-      sandbox.stub(authProviders, 'facebook').callsFake(fakeOAuthRequest);
-      return request(app)
-        .post('/v1/auth/facebook')
-        .send({ access_token: '123' })
-        .expect(httpStatus.OK)
-        .then((res) => {
-          expect(res.body.token).to.have.a.property('accessToken');
-          expect(res.body.token).to.have.a.property('refreshToken');
-          expect(res.body.token).to.have.a.property('expiresIn');
-          expect(res.body.user).to.be.an('object');
-        });
-    });
+  // describe('POST /v1/auth/facebook', () => {
+  //   it('should create a new user and return an accessToken when user does not exist', () => {
+  //     sandbox.stub(authProviders, 'facebook').callsFake(fakeOAuthRequest);
+  //     return request(app)
+  //       .post('/v1/auth/facebook')
+  //       .send({ access_token: '123' })
+  //       .expect(httpStatus.OK)
+  //       .then((res) => {
+  //         expect(res.body.token).to.have.a.property('accessToken');
+  //         expect(res.body.token).to.have.a.property('refreshToken');
+  //         expect(res.body.token).to.have.a.property('expiresIn');
+  //         expect(res.body.user).to.be.an('object');
+  //       });
+  //   });
 
-    it('should return an accessToken when user already exists', async () => {
-      dbUser.email = 'test@test.com';
-      await User.create(dbUser);
-      sandbox.stub(authProviders, 'facebook').callsFake(fakeOAuthRequest);
-      return request(app)
-        .post('/v1/auth/facebook')
-        .send({ access_token: '123' })
-        .expect(httpStatus.OK)
-        .then((res) => {
-          expect(res.body.token).to.have.a.property('accessToken');
-          expect(res.body.token).to.have.a.property('refreshToken');
-          expect(res.body.token).to.have.a.property('expiresIn');
-          expect(res.body.user).to.be.an('object');
-        });
-    });
+  //   it('should return an accessToken when user already exists', async () => {
+  //     dbUser.email = 'test@test.com';
+  //     await User.create(dbUser);
+  //     sandbox.stub(authProviders, 'facebook').callsFake(fakeOAuthRequest);
+  //     return request(app)
+  //       .post('/v1/auth/facebook')
+  //       .send({ access_token: '123' })
+  //       .expect(httpStatus.OK)
+  //       .then((res) => {
+  //         expect(res.body.token).to.have.a.property('accessToken');
+  //         expect(res.body.token).to.have.a.property('refreshToken');
+  //         expect(res.body.token).to.have.a.property('expiresIn');
+  //         expect(res.body.user).to.be.an('object');
+  //       });
+  //   });
 
-    it('should return error when access_token is not provided', async () => {
-      return request(app)
-        .post('/v1/auth/facebook')
-        .expect(httpStatus.BAD_REQUEST)
-        .then((res) => {
-          const field = res.body.errors[0].field;
-          const location = res.body.errors[0].location;
-          const messages = res.body.errors[0].messages;
-          expect(field).to.be.equal('access_token');
-          expect(location).to.be.equal('body');
-          expect(messages).to.include('"access_token" is required');
-        });
-    });
-  });
+  //   it('should return error when access_token is not provided', async () => {
+  //     return request(app)
+  //       .post('/v1/auth/facebook')
+  //       .expect(httpStatus.BAD_REQUEST)
+  //       .then((res) => {
+  //         const field = res.body.errors[0].field;
+  //         const location = res.body.errors[0].location;
+  //         const messages = res.body.errors[0].messages;
+  //         expect(field).to.be.equal('access_token');
+  //         expect(location).to.be.equal('body');
+  //         expect(messages).to.include('"access_token" is required');
+  //       });
+  //   });
+  // });
 
-  describe('POST /v1/auth/google', () => {
-    it('should create a new user and return an accessToken when user does not exist', () => {
-      sandbox.stub(authProviders, 'google').callsFake(fakeOAuthRequest);
-      return request(app)
-        .post('/v1/auth/google')
-        .send({ access_token: '123' })
-        .expect(httpStatus.OK)
-        .then((res) => {
-          expect(res.body.token).to.have.a.property('accessToken');
-          expect(res.body.token).to.have.a.property('refreshToken');
-          expect(res.body.token).to.have.a.property('expiresIn');
-          expect(res.body.user).to.be.an('object');
-        });
-    });
+  // describe('POST /v1/auth/google', () => {
+  //   it('should create a new user and return an accessToken when user does not exist', () => {
+  //     sandbox.stub(authProviders, 'google').callsFake(fakeOAuthRequest);
+  //     return request(app)
+  //       .post('/v1/auth/google')
+  //       .send({ access_token: '123' })
+  //       .expect(httpStatus.OK)
+  //       .then((res) => {
+  //         expect(res.body.token).to.have.a.property('accessToken');
+  //         expect(res.body.token).to.have.a.property('refreshToken');
+  //         expect(res.body.token).to.have.a.property('expiresIn');
+  //         expect(res.body.user).to.be.an('object');
+  //       });
+  //   });
 
-    it('should return an accessToken when user already exists', async () => {
-      dbUser.email = 'test@test.com';
-      await User.create(dbUser);
-      sandbox.stub(authProviders, 'google').callsFake(fakeOAuthRequest);
-      return request(app)
-        .post('/v1/auth/google')
-        .send({ access_token: '123' })
-        .expect(httpStatus.OK)
-        .then((res) => {
-          expect(res.body.token).to.have.a.property('accessToken');
-          expect(res.body.token).to.have.a.property('refreshToken');
-          expect(res.body.token).to.have.a.property('expiresIn');
-          expect(res.body.user).to.be.an('object');
-        });
-    });
+  //   it('should return an accessToken when user already exists', async () => {
+  //     dbUser.email = 'test@test.com';
+  //     await User.create(dbUser);
+  //     sandbox.stub(authProviders, 'google').callsFake(fakeOAuthRequest);
+  //     return request(app)
+  //       .post('/v1/auth/google')
+  //       .send({ access_token: '123' })
+  //       .expect(httpStatus.OK)
+  //       .then((res) => {
+  //         expect(res.body.token).to.have.a.property('accessToken');
+  //         expect(res.body.token).to.have.a.property('refreshToken');
+  //         expect(res.body.token).to.have.a.property('expiresIn');
+  //         expect(res.body.user).to.be.an('object');
+  //       });
+  //   });
 
-    it('should return error when access_token is not provided', async () => {
-      return request(app)
-        .post('/v1/auth/google')
-        .expect(httpStatus.BAD_REQUEST)
-        .then((res) => {
-          const field = res.body.errors[0].field;
-          const location = res.body.errors[0].location;
-          const messages = res.body.errors[0].messages;
-          expect(field).to.be.equal('access_token');
-          expect(location).to.be.equal('body');
-          expect(messages).to.include('"access_token" is required');
-        });
-    });
-  });
+  //   it('should return error when access_token is not provided', async () => {
+  //     return request(app)
+  //       .post('/v1/auth/google')
+  //       .expect(httpStatus.BAD_REQUEST)
+  //       .then((res) => {
+  //         const field = res.body.errors[0].field;
+  //         const location = res.body.errors[0].location;
+  //         const messages = res.body.errors[0].messages;
+  //         expect(field).to.be.equal('access_token');
+  //         expect(location).to.be.equal('body');
+  //         expect(messages).to.include('"access_token" is required');
+  //       });
+  //   });
+  // });
 
   describe('POST /v1/auth/refresh-token', () => {
     it('should return a new accessToken when refreshToken and email match', async () => {
@@ -279,7 +284,7 @@ describe('Authentication API', () => {
         });
     });
 
-    it('should report error when email and refreshToken don\'t match', async () => {
+    it("should report error when email and refreshToken don't match", async () => {
       await RefreshToken.create(refreshToken);
       return request(app)
         .post('/v1/auth/refresh-token')
@@ -311,6 +316,136 @@ describe('Authentication API', () => {
           expect(field2).to.be.equal('refreshToken');
           expect(location2).to.be.equal('body');
           expect(messages2).to.include('"refreshToken" is required');
+        });
+    });
+  });
+
+  describe('POST /v1/auth/password/reset', () => {
+    it('should create a new resetToken when given a valid email match and url', async () => {
+      await ResetToken.create(resetToken);
+      return request(app)
+        .post('/v1/auth/password/reset')
+        .send({ email: dbUser.email, url: 'http://test.com' })
+        .expect(httpStatus.OK)
+        .then((res) => {
+          expect(res.body).to.have.a.property('user');
+          expect(res.body.user).to.have.a.property('id');
+          expect(res.body.user).to.have.a.property('email');
+          expect(res.body).to.have.a.property('message');
+        });
+    });
+
+    it("should report error when email doesn't match in system", async () => {
+      return request(app)
+        .post('/v1/auth/password/reset')
+        .send({ email: user.email, url: 'http://test.com' })
+        .expect(httpStatus.NOT_FOUND)
+        .then((res) => {
+          const code = res.body.code;
+          const message = res.body.message;
+          expect(code).to.be.equal(404);
+          expect(message).to.be.equal('Non-existant email');
+        });
+    });
+
+    it('should report error when email or url are not provided', () => {
+      return request(app)
+        .post('/v1/auth/password/reset')
+        .send({})
+        .expect(httpStatus.BAD_REQUEST)
+        .then((res) => {
+          const field1 = res.body.errors[0].field;
+          const location1 = res.body.errors[0].location;
+          const messages1 = res.body.errors[0].messages;
+          const field2 = res.body.errors[1].field;
+          const location2 = res.body.errors[1].location;
+          const messages2 = res.body.errors[1].messages;
+          expect(field1).to.be.equal('email');
+          expect(location1).to.be.equal('body');
+          expect(messages1).to.include('"email" is required');
+          expect(field2).to.be.equal('url');
+          expect(location2).to.be.equal('body');
+          expect(messages2).to.include('"url" is required');
+        });
+    });
+  });
+
+  describe('POST /v1/auth/password/reset/change', () => {
+    it('should reset password when given a valid email and matching reset token ', async () => {
+      await ResetToken.create(resetToken);
+      await RefreshToken.create(refreshToken);
+      return request(app)
+        .post('/v1/auth/password/reset/change')
+        .send({
+          email: dbUser.email,
+          password: 'sekrit',
+          confirm: 'sekrit',
+          token: resetToken.token,
+        })
+        .expect(httpStatus.OK)
+        .then((res) => {
+          expect(res.body).to.have.a.property('user');
+          expect(res.body.user).to.have.a.property('id');
+          expect(res.body.user).to.have.a.property('email');
+          expect(res.body).to.have.a.property('message');
+          // User password changed
+          expect(User.findById(res.body.user.id).password).to.not.be.equal('mypassword');
+          // All tokens were removed
+          expect(ResetToken.find({}).length).to.be.undefined;
+          expect(RefreshToken.find({}).length).to.be.undefined;
+        });
+    });
+
+    it("should report error when email doesn't match", async () => {
+      return request(app)
+        .post('/v1/auth/password/reset/change')
+        .send({
+          email: 'bad@mail.com',
+          password: 'sekrit',
+          confirm: 'sekrit',
+          token: resetToken.token,
+        })
+        .expect(httpStatus.NOT_FOUND)
+        .then((res) => {
+          const code = res.body.code;
+          const message = res.body.message;
+          expect(code).to.be.equal(404);
+          expect(message).to.be.equal('User email not found or invalid');
+        });
+    });
+
+    it("should report error when token doesn't match", async () => {
+      return request(app)
+        .post('/v1/auth/password/reset/change')
+        .send({ email: dbUser.email, password: 'sekrit', confirm: 'sekrit', token: 'no-match' })
+        .expect(httpStatus.CONFLICT)
+        .then((res) => {
+          const code = res.body.code;
+          const message = res.body.message;
+          expect(code).to.be.equal(409);
+          expect(message).to.be.equal('No matching reset token found for email');
+        });
+    });
+
+    it('should report error when any of the fields are not provided', () => {
+      return request(app)
+        .post('/v1/auth/password/reset/change')
+        .send({})
+        .expect(httpStatus.BAD_REQUEST)
+        .then((res) => {
+          const [email, password, confirm, token] = res.body.errors;
+          expect(email.field).to.be.equal('email');
+          expect(email.location).to.be.equal('body');
+          expect(email.messages).to.include('"email" is required');
+          expect(password.field).to.be.equal('password');
+          expect(password.location).to.be.equal('body');
+          expect(password.messages).to.include('"password" is required');
+          expect(confirm.field).to.be.equal('confirm');
+          expect(confirm.location).to.be.equal('body');
+          expect(confirm.messages).to.include('"confirm" is required');
+          expect(token.field).to.be.equal('token');
+          expect(token.location).to.be.equal('body');
+          expect(token.messages).to.include('"token" is required');
         });
     });
   });

--- a/src/api/tests/unit/nodemailer.test.js
+++ b/src/api/tests/unit/nodemailer.test.js
@@ -1,0 +1,32 @@
+/* eslint-disable arrow-body-style */
+/* eslint-disable no-unused-expressions */
+Promise = require('bluebird'); // eslint-disable-line no-global-assign
+const request = require('supertest');
+const httpStatus = require('http-status');
+const nodemailer = require('nodemailer');
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { some, omitBy, isNil } = require('lodash');
+const { mail } = require('../../utils/email');
+
+// Message object
+const message = {
+  to: 'Recipient <recipient@example.com>',
+  subject: 'Nodemailer is unicode friendly ✔',
+  message: '<p><b>Hello</b> to myself!</p>',
+};
+
+// Setup test case for emailing
+// const transporter = nodemailer.createTransport(config);
+// const testMail = Promise.promisify(transporter.sendMail, { context: transporter });
+
+describe('Able to send email', () => {
+  it('should create a new user when request is ok', function () {
+    this.timeout(4000);
+    return mail(message).then((info) => {
+      expect(info).to.be.an('object');
+      expect(info).to.haveOwnProperty('messageId');
+      expect(info.response).to.match(/^250 Accepted/);
+    });
+  });
+});

--- a/src/api/utils/email.js
+++ b/src/api/utils/email.js
@@ -1,0 +1,33 @@
+const nodemailer = require('nodemailer');
+const config = require('../../config/vars');
+
+const transporter = nodemailer.createTransport(config.mail);
+
+const mailOptions = {
+  from: '"API Service 👻" <ghost@api-service.com>',
+};
+
+const sendMail = Promise.promisify(transporter.sendMail, { context: transporter });
+
+async function mail({ to, subject, message }) {
+  return new Promise((resolve, reject) => {
+    transporter.sendMail(
+      {
+        ...mailOptions,
+        to,
+        subject,
+        html: message,
+      },
+      (err, info) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(info);
+      },
+    );
+  });
+}
+
+module.exports = {
+  mail,
+};

--- a/src/api/validations/auth.validation.js
+++ b/src/api/validations/auth.validation.js
@@ -33,9 +33,32 @@ module.exports = {
         .email()
         .required(),
       url: Joi.string()
-        .uri()
+        // .uri()
         .trim()
         .required(),
+    },
+  },
+
+  passwordResetChange: {
+    body: {
+      email: Joi.string()
+        .email()
+        .required(),
+      password: Joi.string()
+        .required()
+        .max(128),
+      confirm: Joi.string()
+        .required()
+        .max(128)
+        .valid(Joi.ref('password'))
+        .options({
+          language: {
+            any: {
+              allowOnly: 'Passwords do not match',
+            },
+          },
+        }),
+      token: Joi.string().required(),
     },
   },
 

--- a/src/config/vars.js
+++ b/src/config/vars.js
@@ -12,9 +12,16 @@ module.exports = {
   jwtSecret: process.env.JWT_SECRET,
   jwtExpirationInterval: process.env.JWT_EXPIRATION_MINUTES,
   mongo: {
-    uri: process.env.NODE_ENV === 'test'
-      ? process.env.MONGO_URI_TESTS
-      : process.env.MONGO_URI,
+    uri: process.env.NODE_ENV === 'test' ? process.env.MONGO_URI_TESTS : process.env.MONGO_URI,
+  },
+  mail: {
+    host: 'smtp.ethereal.email',
+    port: 587,
+    secure: false,
+    auth: {
+      user: 'imqoag3vwp5pnzx7@ethereal.email',
+      pass: 'E8nFghPzFh5jbyMFS6',
+    },
   },
   logs: process.env.NODE_ENV === 'production' ? 'combined' : 'dev',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,6 +2718,10 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+nodemailer@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-4.1.2.tgz#82e1fb61ddc7272fe4f34c5ba6adaa99faa8b635"
+
 nodemon@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.11.0.tgz#226c562bd2a7b13d3d7518b49ad4828a3623d06c"


### PR DESCRIPTION
- added /auth/password/reset for requesting a password reset given an email and reset link/url
- added /auth/password/reset/change that can be called by the form at the previous reset link with a reset token, email, password & confirm to actually reset password.